### PR TITLE
macports -> homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This script will:
     ./build.sh
 
 This should do everything you need. If you don't have 
-mkisofs, install macports, then:
+mkisofs, install [homebrew](http://mxcl.github.com/homebrew/), then:
 
     brew install cdrtools
 


### PR DESCRIPTION
The example used the `brew` command, but the text above it used "macports". This replaces it with a link to the homebrew home page.
