### PR TITLE
Making it work on OSX 10.7.4, where tar fails silently to extract the iso

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ mkisofs, install [homebrew](http://mxcl.github.com/homebrew/), then:
 
     brew install cdrtools
 
+Possible extra steps for OSX Lion:
+
+ - You may have trouble compiling the `smake` dependency of cdrtools with XCode 4.2.x or earlier. If compilation hangs, upgrade to XCode 4.3.x (free app store upgrade), open XCode and install the Command Line Tools (Preferences -> Downloads).
+ - tar 2.8.3 with libarchive 2.8.3 may fail to extract from the ISO image.  If this happens, update libarchive (will install to `/usr/local/bin/bsdtar`, won't overwrite system tar)
+  
+        brew install https://raw.github.com/oschrenk/homebrew-dupes/edbc2b464d0bf4420508297418481178299f420a/libarchive.rb
+
 ### Ben's notes
 
 Forked Carl's repo, and it sort of worked out of the box. Tweaked 

--- a/build.sh
+++ b/build.sh
@@ -59,6 +59,25 @@ if [ ! -e "${FOLDER_ISO}/custom.iso" ]; then
   echo "Untarring downloaded ISO ..."
   tar -C "${FOLDER_ISO_CUSTOM}" -xf "${ISO_FILENAME}"
 
+  # in osx lion 10.7.4, tar won't extract anything and will fail silently. If that happens, look for a newer version of bsd tar
+  if [ ! `ls $FOLDER_ISO_CUSTOM` ]; then
+      TAR_COMMAND=tar
+      if [ -x '/usr/local/bin/bsdtar' ];
+      then
+          LOCAL_BSD_TAR=/usr/local/bin/bsdtar
+      else
+          LOCAL_BSD_TAR=/usr/bin/bsdtar
+      fi
+      echo "tar failed to extract ISO, falling back to $LOCAL_BSD_TAR"
+      "${LOCAL_BSD_TAR}" -C "${FOLDER_ISO_CUSTOM}" -xf "${ISO_FILENAME}"
+  fi
+
+  # If that still didn't work, you have to update tar
+  if [ ! `ls $FOLDER_ISO_CUSTOM` ]; then
+    echo "Error with extracting the ISO file with your version of tar. Try updating to libarchive 3.0.4 (using e.g. the homebrew-dupes project)"
+    exit 1
+  fi
+
   # backup initrd.gz
   echo "Backing up current init.rd ..."
   chmod u+w "${FOLDER_ISO_CUSTOM}/install" "${FOLDER_ISO_CUSTOM}/install/initrd.gz"
@@ -203,6 +222,7 @@ vagrant package --base "${BOX}"
 
 # references:
 # http://blog.ericwhite.ca/articles/2009/11/unattended-debian-lenny-install/
+# http://forums.macrumors.com/showthread.php?t=1377464 # osx lion tar/iso problem
 # http://cdimage.ubuntu.com/releases/precise/beta-2/
 # http://www.imdb.com/name/nm1483369/
 # http://vagrantup.com/docs/base_boxes.html


### PR DESCRIPTION
First of all, great script - it's annoying that the default vagrant box is an old version.

I tried to run it this morning, and ran into a couple of issues - first with brew installing cdrtools (using a slightly outdated version of XCode).  I updated XCode and got that working, but then tar was failing silently on extracting from the ISO file.

I solved the problem by updating to a more recent "homebrew-dupes" version of libarchive as recommended in this thread: http://forums.macrumors.com/showthread.php?t=1377464

This pull request updated the README to outline those two potential issues and their fixes, and I updated `build.sh` to try using the homebrew installed bsdtar if the tar output is empty.

Googling for the first cdrtools problem, I saw it was a common problem with smake and OSX Lion.   And there is an open Github issue on the project for the empty tar output problem, so it seems like other people are having the same problem with tar 2.8.3.
