### PR TITLE
Updates 12.04 to 12.04.2 for download/md5

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,8 +9,8 @@ set -o errexit
 
 # Configurations
 BOX="ubuntu-precise-64"
-ISO_URL="http://releases.ubuntu.com/precise/ubuntu-12.04-alternate-amd64.iso"
-ISO_MD5="9fcc322536575dda5879c279f0b142d7"
+ISO_URL="http://releases.ubuntu.com/precise/ubuntu-12.04.2-alternate-amd64.iso"
+ISO_MD5="cff39ccc589c7797aacce9efee7b5f93"
 
 # location, location, location
 FOLDER_BASE=`pwd`


### PR DESCRIPTION
There was an update on ubuntu's side which broke this script. This should fix it.
